### PR TITLE
Integrate two-player input handling

### DIFF
--- a/input_handler.v
+++ b/input_handler.v
@@ -1,86 +1,129 @@
+// input_handler.v
+// Debounces and synchronizes inputs for two players.
 
 module input_handler (
-    input  wire clk_50Mhz,          // fast clock for debouncing
-    input  wire clk_60Hz_game,      // game logic clock
-    input  wire reset,              // active-HIGH reset
+    input  wire clk,
+    input  wire reset,
 
-    // Raw button inputs (active-LOW)
-    input  wire p1_key_left_raw_in,
-    input  wire p1_key_right_raw_in,
-    input  wire p1_key_attack_raw_in,
-    input  wire p1_key_confirm_raw_in,
+    // Player 1 buttons from onboard keys (active low)
+    input  wire key_p1_left_n,
+    input  wire key_p1_right_n,
+    input  wire key_p1_attack_n,
 
-    // Processed command outputs (active-HIGH)
-    output wire p1_move_left_cmd_out,
-    output wire p1_move_right_cmd_out,
-    output wire p1_attack_cmd_out,
-    output reg  p1_confirm_cmd_out
+    // Player 2 buttons from external GPIO (active high)
+    input  wire gpio_p2_left,
+    input  wire gpio_p2_right,
+    input  wire gpio_p2_attack,
+
+    // Debounced, synchronized outputs (active high)
+    output wire p1_left,
+    output wire p1_right,
+    output wire p1_attack,
+    output wire p2_left,
+    output wire p2_right,
+    output wire p2_attack
 );
 
-    // --- Debounced signals (active-LOW) ---
+    // Debounce player 1 (inputs are active low)
     wire p1_left_db_n;
     wire p1_right_db_n;
-    wire p1_confirm_db_n;
+    wire p1_attack_db_n;
 
-    // Instantiate debouncers for left, right, confirm
-    button_debouncer db_left (
-        .clk_fast        (clk_50Mhz),
-        .reset           (reset),
-        .btn_raw_in      (p1_key_left_raw_in),
+    button_debouncer db_p1_left(
+        .clk_fast(clk),
+        .reset(reset),
+        .btn_raw_in(key_p1_left_n),
         .btn_debounced_out(p1_left_db_n)
     );
-    button_debouncer db_right (
-        .clk_fast        (clk_50Mhz),
-        .reset           (reset),
-        .btn_raw_in      (p1_key_right_raw_in),
+
+    button_debouncer db_p1_right(
+        .clk_fast(clk),
+        .reset(reset),
+        .btn_raw_in(key_p1_right_n),
         .btn_debounced_out(p1_right_db_n)
     );
-    button_debouncer db_confirm (
-        .clk_fast        (clk_50Mhz),
-        .reset           (reset),
-        .btn_raw_in      (p1_key_confirm_raw_in),
-        .btn_debounced_out(p1_confirm_db_n)
+
+    button_debouncer db_p1_attack(
+        .clk_fast(clk),
+        .reset(reset),
+        .btn_raw_in(key_p1_attack_n),
+        .btn_debounced_out(p1_attack_db_n)
     );
 
-    // --- Synchronizers and outputs for left/right/confirm ---
-    reg p1_left_sync1, p1_left_sync2;
-    reg p1_right_sync1, p1_right_sync2;
-    reg p1_confirm_sync1, p1_confirm_sync2;
+    // Debounce player 2 (inputs are active high -> invert for debouncer)
+    wire p2_left_db_n;
+    wire p2_right_db_n;
+    wire p2_attack_db_n;
 
-    always @(posedge clk_60Hz_game or posedge reset) begin
+    button_debouncer db_p2_left(
+        .clk_fast(clk),
+        .reset(reset),
+        .btn_raw_in(~gpio_p2_left),
+        .btn_debounced_out(p2_left_db_n)
+    );
+
+    button_debouncer db_p2_right(
+        .clk_fast(clk),
+        .reset(reset),
+        .btn_raw_in(~gpio_p2_right),
+        .btn_debounced_out(p2_right_db_n)
+    );
+
+    button_debouncer db_p2_attack(
+        .clk_fast(clk),
+        .reset(reset),
+        .btn_raw_in(~gpio_p2_attack),
+        .btn_debounced_out(p2_attack_db_n)
+    );
+
+    // Synchronize debounced levels to clk and convert to active high
+    reg p1_left_sync1,  p1_left_sync2;
+    reg p1_right_sync1, p1_right_sync2;
+    reg p1_attack_sync1, p1_attack_sync2;
+    reg p2_left_sync1,  p2_left_sync2;
+    reg p2_right_sync1, p2_right_sync2;
+    reg p2_attack_sync1, p2_attack_sync2;
+
+    always @(posedge clk or posedge reset) begin
         if (reset) begin
-            p1_left_sync1     <= 1'b0;
-            p1_left_sync2     <= 1'b0;
-            p1_right_sync1    <= 1'b0;
-            p1_right_sync2    <= 1'b0;
-            p1_confirm_sync1  <= 1'b0;
-            p1_confirm_sync2  <= 1'b0;
-            p1_confirm_cmd_out<= 1'b0;
+            p1_left_sync1  <= 1'b0;
+            p1_left_sync2  <= 1'b0;
+            p1_right_sync1 <= 1'b0;
+            p1_right_sync2 <= 1'b0;
+            p1_attack_sync1<= 1'b0;
+            p1_attack_sync2<= 1'b0;
+            p2_left_sync1  <= 1'b0;
+            p2_left_sync2  <= 1'b0;
+            p2_right_sync1 <= 1'b0;
+            p2_right_sync2 <= 1'b0;
+            p2_attack_sync1<= 1'b0;
+            p2_attack_sync2<= 1'b0;
         end else begin
-            // left/right inverted to active-HIGH, then two-flop synced
-            p1_left_sync1     <= ~p1_left_db_n;
-            p1_left_sync2     <= p1_left_sync1;
-            p1_right_sync1    <= ~p1_right_db_n;
-            p1_right_sync2    <= p1_right_sync1;
-            // confirm inverted and synced
-            p1_confirm_sync1  <= ~p1_confirm_db_n;
-            p1_confirm_sync2  <= p1_confirm_sync1;
-            p1_confirm_cmd_out<= p1_confirm_sync2;
+            // Player 1
+            p1_left_sync1  <= ~p1_left_db_n;
+            p1_left_sync2  <= p1_left_sync1;
+            p1_right_sync1 <= ~p1_right_db_n;
+            p1_right_sync2 <= p1_right_sync1;
+            p1_attack_sync1<= ~p1_attack_db_n;
+            p1_attack_sync2<= p1_attack_sync1;
+
+            // Player 2
+            p2_left_sync1  <= ~p2_left_db_n;
+            p2_left_sync2  <= p2_left_sync1;
+            p2_right_sync1 <= ~p2_right_db_n;
+            p2_right_sync2 <= p2_right_sync1;
+            p2_attack_sync1<= ~p2_attack_db_n;
+            p2_attack_sync2<= p2_attack_sync1;
         end
     end
 
-    // Movement commands driven from first sync stage (1-tick latency)
-    assign p1_move_left_cmd_out   = p1_left_sync1;
-    assign p1_move_right_cmd_out  = p1_right_sync1;
-
-    // --- Attack path: bypass debounce, single-flop sync ---
-    reg p1_attack_sync1;
-    always @(posedge clk_60Hz_game or posedge reset) begin
-        if (reset)
-            p1_attack_sync1 <= 1'b0;
-        else
-            p1_attack_sync1 <= ~p1_key_attack_raw_in; // direct raw inversion
-    end
-    assign p1_attack_cmd_out = p1_attack_sync1;
+    // Final outputs
+    assign p1_left   = p1_left_sync2;
+    assign p1_right  = p1_right_sync2;
+    assign p1_attack = p1_attack_sync2;
+    assign p2_left   = p2_left_sync2;
+    assign p2_right  = p2_right_sync2;
+    assign p2_attack = p2_attack_sync2;
 
 endmodule
+


### PR DESCRIPTION
## Summary
- expose GPIO player 2 inputs alongside KEY[2:0]
- instantiate `input_handler` in the top module
- drive player logic with debounced player 1 controls
- store extra player 2 button states for future logic

## Testing
- `verilator --lint-only EE314_GROUP38.v input_handler.v button_debouncer.v` *(fails: command not found)*
- `iverilog -tnull EE314_GROUP38.v input_handler.v button_debouncer.v` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68518ae078308332840dec43bbb5c914