### PR TITLE
Add support for player 2 controls

### DIFF
--- a/EE314_GROUP38.v
+++ b/EE314_GROUP38.v
@@ -118,14 +118,21 @@ wire [2:0] p1_health, p2_health;
     wire [9:0] char_y_pos;
     wire [9:0] char_width;
     wire [9:0] char_height;
-    wire [7:0] char_color_332;	// RRRGGGBB from test pattern generator
+    wire [7:0] char_color_332;	// Player 1 color
+    // Player 2 sprite wires
+    wire [9:0] char2_x_pos;
+    wire [9:0] char2_y_pos;
+    wire [9:0] char2_width;
+    wire [9:0] char2_height;
+    wire [7:0] char2_color_332;
 
     wire [7:0] background_pixel_color_332;  // Output of background_generator
     wire [7:0] char_rendered_pixel_color_332;        // Color output of character_renderer
     wire       char_is_visible_at_pixel;    // Visibility flag from character_renderer
     wire [7:0] final_pixel_color_to_vga_332; // Output of graphics_mixer
 
-	 wire [1:0]  attack_phase;
+    wire [1:0] attack_phase;
+    wire [1:0] attack_phase_p2;
 	 
 	   wire frame_sync;
     wire vblank;
@@ -163,12 +170,28 @@ game_clocks clocks_inst (
     .move_left_cmd_in(p1_left && (current_game_state == 3'b010)), // Only in gameplay
     .move_right_cmd_in(p1_right && (current_game_state == 3'b010)), // Only in gameplay
     .p1_attack_cmd_in(p1_attack && (current_game_state == 3'b010)), // Only in gameplay
+    .init_x_pos(10'd304),
     .char_x_pos_out(char_x_pos),
     .char_y_pos_out(char_y_pos),
     .char_width_out(char_width),
     .char_height_out(char_height),
     .char_color_out_332(char_color_332),
     .attack_phase_out(attack_phase)
+);
+
+    player_logic player2_logic_inst (
+    .clk_game(clk_game),
+    .reset(reset_gameplay),
+    .move_left_cmd_in(p2_left && (current_game_state == 3'b010)),
+    .move_right_cmd_in(p2_right && (current_game_state == 3'b010)),
+    .p1_attack_cmd_in(p2_attack && (current_game_state == 3'b010)),
+    .init_x_pos(10'd500),
+    .char_x_pos_out(char2_x_pos),
+    .char_y_pos_out(char2_y_pos),
+    .char_width_out(char2_width),
+    .char_height_out(char2_height),
+    .char_color_out_332(char2_color_332),
+    .attack_phase_out(attack_phase_p2)
 );
 	 
     // --- Test Pattern Generator ---
@@ -202,12 +225,19 @@ graphics_mixer mixer_inst (
     .pixel_x(current_pixel_x),
     .pixel_y(current_pixel_y),
     .background_color_in_332(background_pixel_color_332),
-    .char_x_pos(char_x_pos),
-    .char_y_pos(char_y_pos),
-    .char_width(char_width),
-    .char_height(char_height),
-    .char_color_in_332(char_color_332),
-    .attack_phase(attack_phase),
+    .char1_x_pos(char_x_pos),
+    .char1_y_pos(char_y_pos),
+    .char1_width(char_width),
+    .char1_height(char_height),
+    .char1_color_in_332(char_color_332),
+    .char1_attack_phase(attack_phase),
+
+    .char2_x_pos(char2_x_pos),
+    .char2_y_pos(char2_y_pos),
+    .char2_width(char2_width),
+    .char2_height(char2_height),
+    .char2_color_in_332(char2_color_332),
+    .char2_attack_phase(attack_phase_p2),
     .current_game_state(current_game_state),     // ADD THIS
     .menu_color_in_332(menu_color_332),          // ADD THIS  
     .menu_pixel_visible(menu_pixel_visible),     // ADD THIS

--- a/graphics_mixer.v
+++ b/graphics_mixer.v
@@ -9,13 +9,21 @@ module graphics_mixer (
     // Background generator output
     input  wire [7:0]  background_color_in_332, // RRRGGGBB format
 
-    // Character geometry & appearance from player_logic
-    input  wire [9:0]  char_x_pos,              // top-left X of character
-    input  wire [9:0]  char_y_pos,              // top-left Y of character
-    input  wire [9:0]  char_width,              // width in pixels
-    input  wire [9:0]  char_height,             // height in pixels
-    input  wire [7:0]  char_color_in_332,       // body (hurtbox) color
-    input  wire [1:0]  attack_phase,            // 00=none, 01=startup, 10=active, 11=recovery
+    // Player 1 geometry & appearance
+    input  wire [9:0]  char1_x_pos,
+    input  wire [9:0]  char1_y_pos,
+    input  wire [9:0]  char1_width,
+    input  wire [9:0]  char1_height,
+    input  wire [7:0]  char1_color_in_332,
+    input  wire [1:0]  char1_attack_phase,
+
+    // Player 2 geometry & appearance
+    input  wire [9:0]  char2_x_pos,
+    input  wire [9:0]  char2_y_pos,
+    input  wire [9:0]  char2_width,
+    input  wire [9:0]  char2_height,
+    input  wire [7:0]  char2_color_in_332,
+    input  wire [1:0]  char2_attack_phase,
 
     // Menu system inputs - ADD THESE
     input  wire [2:0]  current_game_state,      // Game state
@@ -36,25 +44,44 @@ module graphics_mixer (
     wire gameplay_active = (current_game_state == STATE_GAMEPLAY);
 
     // Wires to capture character_renderer outputs
-    wire [7:0] sprite_color;
-    wire       sprite_visible;
+    wire [7:0] sprite1_color;
+    wire       sprite1_visible;
+    wire [7:0] sprite2_color;
+    wire       sprite2_visible;
 
-    // Character renderer (only for gameplay)
-    character_renderer char_inst (
+    // Character renderer for player 1
+    character_renderer char1_inst (
+        .display_enable               (display_enable),
+        .current_pixel_x              (pixel_x),
+        .current_pixel_y              (pixel_y),
+        .char_x_pos_in                (char1_x_pos),
+        .char_y_pos_in                (char1_y_pos),
+        .char_width_in                (char1_width),
+        .char_height_in               (char1_height),
+        .char_color_in_332            (char1_color_in_332),
+
+        .attack_phase_in              (char1_attack_phase),
+
+        .char_pixel_color_out_332     (sprite1_color),
+        .char_is_visible_at_pixel_out (sprite1_visible)
+    );
+
+    // Character renderer for player 2
+    character_renderer char2_inst (
         .display_enable               (display_enable),
         .current_pixel_x              (pixel_x),
         .current_pixel_y              (pixel_y),
 
-        .char_x_pos_in                (char_x_pos),
-        .char_y_pos_in                (char_y_pos),
-        .char_width_in                (char_width),
-        .char_height_in               (char_height),
-        .char_color_in_332            (char_color_in_332),
+        .char_x_pos_in                (char2_x_pos),
+        .char_y_pos_in                (char2_y_pos),
+        .char_width_in                (char2_width),
+        .char_height_in               (char2_height),
+        .char_color_in_332            (char2_color_in_332),
 
-        .attack_phase_in              (attack_phase),
+        .attack_phase_in              (char2_attack_phase),
 
-        .char_pixel_color_out_332     (sprite_color),
-        .char_is_visible_at_pixel_out (sprite_visible)
+        .char_pixel_color_out_332     (sprite2_color),
+        .char_is_visible_at_pixel_out (sprite2_visible)
     );
 
     // Final mixing logic
@@ -64,9 +91,11 @@ module graphics_mixer (
         end else if (menu_pixel_visible) begin
             // Menu/countdown takes highest priority
             final_pixel_color_out_332 = menu_color_in_332;
-        end else if (gameplay_active && sprite_visible) begin
-            // Character sprites only in gameplay mode
-            final_pixel_color_out_332 = sprite_color;
+        end else if (gameplay_active && sprite2_visible) begin
+            // Player 2 sprite has priority
+            final_pixel_color_out_332 = sprite2_color;
+        end else if (gameplay_active && sprite1_visible) begin
+            final_pixel_color_out_332 = sprite1_color;
         end else begin
             // Background
             final_pixel_color_out_332 = background_color_in_332;

--- a/player_logic.v
+++ b/player_logic.v
@@ -1,7 +1,10 @@
 
 module player_logic (
-    input  wire        clk_game,           
-    input  wire        reset,              
+    input  wire        clk_game,
+    input  wire        reset,
+
+    // Starting X position for this player
+    input  wire [9:0]  init_x_pos,
 
     input  wire        move_left_cmd_in,
     input  wire        move_right_cmd_in,
@@ -13,7 +16,7 @@ module player_logic (
     output wire [9:0]  char_width_out,     // sprite width
     output wire [9:0]  char_height_out,    // sprite height
     output reg  [7:0]  char_color_out_332, // sprite color (3-3-2)
-output wire [1:0] attack_phase_out,
+    output wire [1:0]  attack_phase_out,
     
     output wire        attack_active      
 );
@@ -87,7 +90,7 @@ output wire [1:0] attack_phase_out,
     // Main FSM + movement
     always @(posedge clk_game or posedge reset) begin
         if (reset) begin
-            char_x_pos_out     <= P_INIT_X;
+            char_x_pos_out     <= init_x_pos;
             char_color_out_332 <= COL_IDLE;
             state_reg          <= S_IDLE;
             timer_reg          <= 8'd0;


### PR DESCRIPTION
## Summary
- allow `player_logic` instances to set a custom start X via new `init_x_pos` input
- instantiate a second `player_logic` in the top level and route player 2 inputs
- extend `graphics_mixer` to draw sprites for both players

## Testing
- `iverilog -o test.out *.v` *(fails: menu_screen.v syntax error)*

------
https://chatgpt.com/codex/tasks/task_e_6851aae506208332a471bf2db274ac8f